### PR TITLE
完成登录模块连接数据库 & springboot 的mysql中配置下划线到驼峰

### DIFF
--- a/src/main/java/hello/configuration/WebSecurityConfig.java
+++ b/src/main/java/hello/configuration/WebSecurityConfig.java
@@ -1,7 +1,6 @@
 package hello.configuration;
 
 import hello.service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -9,7 +8,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import javax.inject.Inject;
@@ -18,9 +16,8 @@ import javax.inject.Inject;
 @EnableWebSecurity
 // 告诉spring 加上web安全模块，设置后，所有的请求都会被拦截
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
-
     @Inject
-    private UserDetailsService userDetailsService;
+    private UserService userService;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -35,20 +32,19 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     // 鉴权
     @Bean
-    @Override
-    public AuthenticationManager authenticationManager() throws Exception {
-        return super.authenticationManager();
+    public AuthenticationManager customAuthenticationManager() throws Exception {
+        return authenticationManager();
     }
 
     // 全局的加密服务
     @Inject
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(userDetailsService).passwordEncoder(bCryptPasswordEncoder());
+        auth.userDetailsService(userService).passwordEncoder(bCryptPasswordEncoder());
     }
 
     // 对存储到数据库的密码进行加密
     @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
         return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/hello/controller/AuthController.java
+++ b/src/main/java/hello/controller/AuthController.java
@@ -2,7 +2,6 @@ package hello.controller;
 
 import hello.entity.User;
 import hello.service.UserService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
+import javax.inject.Inject;
 import java.util.Map;
 
 // Filter->构造Token->AuthenticationManager->转给Provider处理->认证处理成功后续操作或者不通过抛异常
@@ -19,7 +19,7 @@ public class AuthController {
     private UserService userService;
     private AuthenticationManager authenticationManager;
 
-    @Autowired
+    @Inject
     public AuthController(UserService userService, AuthenticationManager authenticationManager) {
         this.userService = userService;
         this.authenticationManager = authenticationManager;
@@ -30,12 +30,12 @@ public class AuthController {
     public Object auth() {
         // 这里没有接入数据库，保存的信息是在内存中的，因此暂时读取不到，返回的是anonymousUser 匿名用户
         String userName = SecurityContextHolder.getContext().getAuthentication().getName();
-        User loggedInUser = userService.getUserByUsername(userName);
+        User loggedInUser = userService.findUserByUsername(userName);
 
         if (loggedInUser == null) {
             return new Result("ok", "用户没有登录", false);
         }
-        return new Result("ok", null, true, userService.getUserByUsername(userName));
+        return new Result("ok", null, true, userService.findUserByUsername(userName));
     }
 
     @PostMapping("/auth/login")
@@ -67,7 +67,7 @@ public class AuthController {
             // Cookie
             SecurityContextHolder.getContext().setAuthentication(token);
 
-            return new Result("ok", "登录成功", true, userService.getUserByUsername(username));
+            return new Result("ok", "登录成功", true, userService.findUserByUsername(username));
         } catch (BadCredentialsException e) {
             return new Result("fail", "密码不正确", false);
         }
@@ -79,11 +79,11 @@ public class AuthController {
         boolean isLogin;
         Object data;
 
-        public Result(String status, String msg, boolean isLogin) {
+        Result(String status, String msg, boolean isLogin) {
             this(status, msg, isLogin, null);
         }
 
-        public Result(String status, String msg, boolean isLogin, Object data) {
+        Result(String status, String msg, boolean isLogin, Object data) {
             this.status = status;
             this.msg = msg;
             this.isLogin = isLogin;

--- a/src/main/java/hello/dao/UserMapper.java
+++ b/src/main/java/hello/dao/UserMapper.java
@@ -1,0 +1,16 @@
+package hello.dao;
+
+import hello.entity.User;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+
+@Mapper
+public interface UserMapper {
+    @Select("select * from user where username = #{username}")
+    User findUserByUsername(@Param("username") String username);
+
+    @Select("insert into user(username, encrypted_password, created_at, updated_at) " +
+            "values(#{username}, #{encryptedPassword}, now(), now())")
+    void save(@Param("username") String username, @Param("encryptedPassword") String encryptedPassword);
+}

--- a/src/main/java/hello/service/UserService.java
+++ b/src/main/java/hello/service/UserService.java
@@ -1,6 +1,7 @@
 package hello.service;
 
 import hello.entity.User;
+import hello.dao.UserMapper;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -9,42 +10,36 @@ import org.springframework.stereotype.Service;
 
 import javax.inject.Inject;
 import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 // 之前使用WebSecurityConfig中的UserDetailsService是Mock的，现在来实现
 @Service
 public class UserService implements UserDetailsService {
+
     private BCryptPasswordEncoder bCryptPasswordEncoder;
-    private Map<String, User> users = new ConcurrentHashMap<>();
+    private UserMapper userMapper;
 
     @Inject
-    public UserService(BCryptPasswordEncoder bCryptPasswordEncoder) {
+    public UserService(BCryptPasswordEncoder bCryptPasswordEncoder, UserMapper userMapper) {
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
-        // 测试
+        this.userMapper = userMapper;
         save("abc", "abc");
     }
 
     public void save(String username, String password) {
-        users.put(username, new User(1, username, bCryptPasswordEncoder.encode(password)));
+        userMapper.save(username, bCryptPasswordEncoder.encode(password));
     }
 
-
-    public User getUserById(Integer id) {
-        return null;
-    }
-
-    public User getUserByUsername(String username) {
-        return users.get(username);
+    public User findUserByUsername(String username) {
+        return userMapper.findUserByUsername(username);
     }
 
     // 自定义UserDetailsService
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        if (!users.containsKey(username)) {
+        if (findUserByUsername(username) == null) {
             throw new UsernameNotFoundException(username + "不存在！");
         }
-        User user = users.get(username);
+        User user = findUserByUsername(username);
 
         return new org.springframework.security.core.userdetails.User(username, user.getEncryptedPassword(), Collections.emptyList());
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/test
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=my-secret-pw
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+mybatis.configuration.map-underscore-to-camel-case=true
 mybatis.config-location=classpath:db/mybatis/config.xml

--- a/src/main/resources/db/migration/V1__Initial_Create_Tables.sql
+++ b/src/main/resources/db/migration/V1__Initial_Create_Tables.sql
@@ -1,0 +1,9 @@
+create table user
+(
+    id                 bigint primary key auto_increment,
+    username           varchar(100),
+    encrypted_password varchar(100),
+    avatar             varchar(100),
+    created_at         timestamp,
+    updated_at         timestamp
+)


### PR DESCRIPTION
1. dao负责数据库相关操作，使用mybatis时，可以使用注解interface来定义Mapper，也可以直接使用xml文件配置，xml适用于较复杂的sql语句
2.springboot 下需要配置mysql下划线到驼峰的转换，在application.properties中引入mybatis/config.xml和同时有mybatis.configuration.map-underscore-to-camel-case=true会出现报错
3.controller主要负责http请求与响应，service单独做服务，controller直接调用service，避免controller代码冗杂